### PR TITLE
Push checking down into `send` and `end`

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -12,7 +12,7 @@ module.exports = mock;
  */
 function mock (superagent, config) {
   var Request = superagent.Request;
-  var parsers = [];
+  var parsers = Object.create(null);
 
   /**
    * Keep the default methods
@@ -27,47 +27,23 @@ function mock (superagent, config) {
    * Attempt to match url against the patterns in fixtures.
    */
   function testUrlForPatterns(url) {
-    if (parsers[url]) { return; }
+    if (parsers.hasOwnProperty(url)) { return parsers[url]; }
 
     var match = config.filter(function (parser) {
       return new RegExp(parser.pattern, 'g').test(url);
     })[0] || null;
 
-    if (match) {
-      parsers[url] = match;
-    }
+    parsers[url] = match;
+    
+    return match;
   }
-
-  /**
-   * Override get function
-   */
-  superagent.get = function (url, data, fn) {
-    testUrlForPatterns(url);
-    return parsers[url] ? superagent('GET', url, data, fn) : oldGet.call(this, url, data, fn);
-  };
-
-  /**
-   * Override post function
-   */
-   superagent.post = function (url, data, fn) {
-     testUrlForPatterns(url);
-     return parsers[url] ? superagent('POST', url, data, fn) : oldPost.call(this, url, data, fn);
-   };
-
-  /**
-   * Override put function
-   */
-   superagent.put = function (url, data, fn) {
-     testUrlForPatterns(url);
-     return parsers[url] ? superagent('PUT', url, data, fn) : oldPut.call(this, url, data, fn);
-   };
 
   /**
    * Override send function
    */
   Request.prototype.send = function (data) {
 
-    var parser = parsers[this.url];
+    var parser = testUrlForPatterns(this.url);
     if (parser) {
       this.params = data;
 
@@ -102,7 +78,7 @@ function mock (superagent, config) {
       path += (~path.indexOf('?') ? '&' : '?') + querystring;
     }
 
-    var parser = parsers[this.url];
+    var parser = testUrlForPatterns(this.url);
 
     if (parser) {
       var match = new RegExp(parser.pattern, 'g').exec(path);


### PR DESCRIPTION
This is a compatibility request from lightsofapollo/superagent-promise. We provide our own implementations of `get`, `put`, and `post` and so cannot take advantage of this module.

Since you call `testUrlForPatterns` before every `get`, `put`, or `post` pushing the testing down shouldn't affect performance much (unless you have a really `option` heavy workload... 

Also changing the memoization technique should net performance gains for non-mocked URLs.
